### PR TITLE
Flush stdout

### DIFF
--- a/examples/usbcat/device.py
+++ b/examples/usbcat/device.py
@@ -185,6 +185,7 @@ class SubprocessCat(ConfigFunctionFFSSubprocess):
             if self.__out_encoding is None else
             value.decode('utf-8', errors='replace')
         )
+        sys.stdout.flush()
 
     def __onCanSend(self):
         self.__epoll.register(sys.stdin, select.EPOLLIN)


### PR DESCRIPTION
stdout is not flushed, hence there may not be output. I don't think this is the expected behavior for an example but correct me if the non-buffering is intentional. There may be more of these cases but I only used the "device.py" code.

![image](https://github.com/vpelletier/python-functionfs/assets/122271989/f5a5d4d8-89c6-485f-bde7-40351a43ca2f)

